### PR TITLE
feat: set presence and mute thread

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -189,8 +189,14 @@ export default class LinkedIn implements PlatformAPI {
   editMessage = this.api.editMessage
 
   sendActivityIndicator = async (type: ActivityType, threadID: string) => {
-    if (type === ActivityType.TYPING) await this.api.sendTypingState(threadID)
-    if (type === ActivityType.ONLINE || type === ActivityType.OFFLINE) await this.api.sendPresenceChange(type)
+    switch (type) {
+      case ActivityType.TYPING:
+        await this.api.sendTypingState(threadID)
+        break
+      case ActivityType.ONLINE:
+      case ActivityType.OFFLINE:
+        await this.api.sendPresenceChange(type)
+    }
   }
 
   addReaction = async (threadID: string, messageID: string, reactionKey: string) => {
@@ -223,7 +229,7 @@ export default class LinkedIn implements PlatformAPI {
 
   updateThread = async (threadID: string, updates: Partial<Thread>) => {
     if (updates.title) await this.api.renameThread(threadID, updates.title)
-    if (updates.mutedUntil || updates.mutedUntil === null) await this.api.sendMutePatch(threadID, updates.mutedUntil)
+    if ('mutedUntil' in updates) await this.api.sendMutePatch(threadID, updates.mutedUntil)
 
     return true
   }

--- a/src/lib/linkedin.ts
+++ b/src/lib/linkedin.ts
@@ -482,7 +482,7 @@ export default class LinkedInAPI {
   sendMutePatch = async (threadID: string, mutedUntil: 'forever' | Date | null): Promise<void> => {
     const url = `${LinkedInURLs.API_CONVERSATIONS}/${encodeURIComponent(threadID)}`
     const value = !!(mutedUntil === 'forever')
-    const payload = { patch: { "$set": { "muted": value } } }
+    const payload = { patch: { $set: { muted: value } } }
 
     await this.fetch({
       url,

--- a/src/mappers.ts
+++ b/src/mappers.ts
@@ -127,7 +127,7 @@ const mapThread = (thread: any, entitiesMap: Record<string, any>, currentUserID:
     isUnread: !conversation.read,
     timestamp: new Date(conversation?.lastActivityAt),
     isReadOnly: false,
-    mutedUntil: !!conversation.muted ? 'forever' : undefined,
+    mutedUntil: conversation.muted ? 'forever' : undefined,
     messages: { items: messages, hasMore: true },
     participants: { items: participantsItems, hasMore: false },
     isArchived: conversation.archived || undefined,


### PR DESCRIPTION
This fixes [TXT-994](https://linear.app/texts/issue/TXT-994/linkedin-support-muteduntil-in-updatethread) and [PLT-579](https://linear.app/texts/issue/PLT-579/linkedin-support-onlineoffline-indicator)

# Changes

- Add presence support
- Add mute / unmute support
