### PR TITLE
Support quoted messages

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -22,7 +22,7 @@ export default class LinkedIn implements PlatformAPI {
 
   onEvent: OnServerEventCallback
 
-  readonly api = new LinkedInAPI()
+  api: LinkedInAPI = new LinkedInAPI()
 
   private myNetwork: MyNetwork
 
@@ -39,9 +39,13 @@ export default class LinkedIn implements PlatformAPI {
   init = async (serialized: { cookies: CookieJar.Serialized }, _: ClientContext, preferences: Record<string, unknown> = {}) => {
     const { cookies } = serialized || {}
     if (!cookies) return
+
     if (preferences.showMyNetwork) {
       this.myNetwork = new MyNetwork(this)
     }
+
+    this.api.setAccountID(this.accountID)
+
     await this.afterAuth(cookies)
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,8 +29,7 @@ export const LinkedInURLs = {
 
 export const GraphQLRecipes = {
   messages: {
-    getMessagesByAnchorTimestamp: 'messengerMessages.41f713c7de5635f9e81d2b0dfc65df1b',
-    getWithCursor: 'messengerMessages.377636847892a71d7e915107d5b4abc1',
+    getMessagesByAnchorTimestamp: 'messengerMessages.8078e691076ceb6cef7a35504dae2390',
     getReactionParticipantsByMessageAndEmoji: 'messengerMessagingParticipants.d8df65a2f55f270ced7e37ff2fafc8c8',
   },
   conversations: {

--- a/src/info.ts
+++ b/src/info.ts
@@ -63,6 +63,7 @@ const info: PlatformInfo = {
     Attribute.SUPPORTS_PUSH_NOTIFICATIONS,
     Attribute.SINGLE_THREAD_CREATION_REQUIRES_MESSAGE,
     Attribute.GROUP_THREAD_CREATION_REQUIRES_MESSAGE,
+    Attribute.SUPPORTS_QUOTED_MESSAGES,
   ]),
   getUserProfileLink: ({ id }) => `https://www.linkedin.com/in/${id}/`,
   prefs: {

--- a/src/lib/types/messages.ts
+++ b/src/lib/types/messages.ts
@@ -115,6 +115,22 @@ type RenderContent = GraphQLNode<{
   forwardedMessageContent: any
   hostUrnData: HostUrnData
   vectorImage?: VectorImage
+  repliedMessageContent?: RepliedMessageContent
+}>
+
+export type RepliedMessageContent = GraphQLNode<{
+  messageBody: {
+    attributes: Attribute[]
+    text: string
+  }
+  originalMessage: {
+    entityUrn: string
+  }
+  originalSender: {
+    entityUrn: string
+    // @TODO update type
+  }
+  originalSendAt: number
 }>
 
 export type HostUrnData = GraphQLNode<{


### PR DESCRIPTION
## Context

LinkedIn started supporting quoted messages (replies) so this PR adds support for that feature.


## Description

Some considerations: 
- LinkedIn forces us to send everything (every field) in their format when quoting a message - so that's why we needed to create a `messagesCache` map variable that will store messages in LinkedIn format.
- We also needed to update the query ID (graphql) to get the quoted message's information.
- They still don't add fully support on the real-time client (official) so they're sending the quoted message as the preview of a forward message but to differentiate it they're sending it one level deeper than normal forwarded messages.

